### PR TITLE
Add sequential filter walkthrough with student-friendly narration

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -200,12 +200,6 @@ body {
   color: #475569;
 }
 
-.kernels-grid {
-  display: grid;
-  gap: 1.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
 .kernel-card {
   background: linear-gradient(160deg, rgba(255, 255, 255, 0.9), rgba(226, 232, 240, 0.9));
   border-radius: 22px;
@@ -216,11 +210,26 @@ body {
   gap: 1.1rem;
 }
 
+.kernel-card--single {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
 .kernel-card__header {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
   gap: 0.5rem;
+}
+
+.kernel-card__subtitle {
+  display: inline-block;
+  margin-bottom: 0.25rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #64748b;
 }
 
 .kernel-card__header h3 {
@@ -238,7 +247,14 @@ body {
   border-radius: 999px;
 }
 
-.kernel-card__description {
+.kernel-card__explanation {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.kernel-card__note {
   margin: 0;
   color: #475569;
   font-size: 0.95rem;
@@ -247,6 +263,66 @@ body {
 .kernel-card__maps {
   display: grid;
   gap: 0.85rem;
+}
+
+.kernel-stepper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.kernel-stepper__controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.kernel-stepper__progress {
+  font-weight: 600;
+  color: #1e3a8a;
+  background: rgba(59, 130, 246, 0.12);
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+}
+
+.kernel-stepper__buttons {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.kernel-stepper__button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.3rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #ffffff;
+  background: linear-gradient(135deg, #2563eb, #38bdf8);
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.22);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.kernel-stepper__button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px rgba(37, 99, 235, 0.22);
+}
+
+.kernel-stepper__button:disabled {
+  cursor: default;
+  opacity: 0.45;
+  box-shadow: none;
+}
+
+.kernel-stepper__empty {
+  margin: 0;
+  font-size: 1rem;
+  color: #475569;
+  background: rgba(148, 163, 184, 0.18);
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
 }
 
 .prediction-block {

--- a/src/cnn.ts
+++ b/src/cnn.ts
@@ -4,14 +4,17 @@ export type KernelInfo = {
   id: string;
   label: string;
   description: string;
+  studentExplanation: string;
   matrix: Matrix;
 };
 
 export const HANDCRAFTED_KERNELS: KernelInfo[] = [
   {
     id: 'vertical-edge',
-    label: 'Vertical Edge Detector',
-    description: 'Highlights tall strokes such as the body of a 1 or the sides of a 0.',
+    label: 'Вертикальный фильтр',
+    description: 'Находит высокие вертикальные штрихи: палочку у «1» или стенки у «0».',
+    studentExplanation:
+      'Представь линейку, которую мы держим вертикально. Если под ней есть тёмная полоска, фильтр загорается.',
     matrix: [
       [1, 0, -1],
       [1, 0, -1],
@@ -20,8 +23,10 @@ export const HANDCRAFTED_KERNELS: KernelInfo[] = [
   },
   {
     id: 'horizontal-edge',
-    label: 'Horizontal Edge Detector',
-    description: 'Emphasises horizontal bars that digits like 2, 3, 4, or 7 rely on.',
+    label: 'Горизонтальный фильтр',
+    description: 'Замечает горизонтальные перекладины, важные для «2», «3», «4» или «7».',
+    studentExplanation:
+      'Этот фильтр словно ищет полочки и крышечки: если в цифре есть полоска поперёк, он сообщает об этом.',
     matrix: [
       [1, 1, 1],
       [0, 0, 0],
@@ -30,8 +35,10 @@ export const HANDCRAFTED_KERNELS: KernelInfo[] = [
   },
   {
     id: 'main-diagonal',
-    label: 'Main Diagonal Detector',
-    description: 'Responds to strokes going from top-left to bottom-right, useful for 2, 3, 7, and 9.',
+    label: 'Главная диагональ',
+    description: 'Ищет линии сверху слева вниз направо: такие штрихи есть у «2», «3», «7» и «9».',
+    studentExplanation:
+      'Подумай о наклонной линии, которая спускается, как горка. Когда цифра содержит такую линию, фильтр видит её.',
     matrix: [
       [0, 1, 1],
       [-1, 0, 1],
@@ -40,8 +47,10 @@ export const HANDCRAFTED_KERNELS: KernelInfo[] = [
   },
   {
     id: 'anti-diagonal',
-    label: 'Anti-Diagonal Detector',
-    description: 'Catches strokes that go from bottom-left to top-right, common in 4 and 9.',
+    label: 'Обратная диагональ',
+    description: 'Реагирует на линии снизу слева вверх направо, например у «4» и «9».',
+    studentExplanation:
+      'Это как наклонная лестница, которая поднимается в гору. Если цифра поднимает линию вверх вправо, фильтр это замечает.',
     matrix: [
       [1, 1, 0],
       [1, 0, -1],
@@ -50,8 +59,10 @@ export const HANDCRAFTED_KERNELS: KernelInfo[] = [
   },
   {
     id: 'stroke-enhancer',
-    label: 'Stroke Enhancer',
-    description: 'Boosts thick strokes and suppresses the background to isolate the digit.',
+    label: 'Усилитель штрихов',
+    description: 'Делает жирные штрихи ярче, а фон тише, чтобы выделить цифру.',
+    studentExplanation:
+      'Представь маркер, который подчёркивает самые яркие части твоего рисунка и стирает лишние пятна вокруг.',
     matrix: [
       [0, -1, 0],
       [-1, 5, -1],
@@ -60,8 +71,10 @@ export const HANDCRAFTED_KERNELS: KernelInfo[] = [
   },
   {
     id: 'blob-detector',
-    label: 'Blob Detector',
-    description: 'Acts like a blur that keeps filled loops such as the belly of an 8 or 0.',
+    label: 'Фильтр пятен',
+    description: 'Любит круглые пятна и петельки — например, «животик» у «8» или «0».',
+    studentExplanation:
+      'Он смотрит на большие закрашенные области. Чем больше залитая часть, тем сильнее реакция фильтра.',
     matrix: [
       [1, 1, 1],
       [1, 1, 1],


### PR DESCRIPTION
## Summary
- present convolution filters one by one with navigation controls and progress information
- translate kernel metadata and add student-friendly explanations for each filter
- style the walkthrough card and buttons to support the sequential presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e69e9258d08327b1211de087dd5991